### PR TITLE
add support to creating docker image for arm64

### DIFF
--- a/inventories/production/group_vars/all.yml
+++ b/inventories/production/group_vars/all.yml
@@ -26,6 +26,8 @@ graphql_dir: /opt/ResilientDB-GraphQL
 crow_port: 18000
 graphql_port: 8000
 bazel_version: 6.0.0
-java_home: /usr/lib/jvm/java-11-openjdk-amd64
+java_home_map:
+  x86_64: /usr/lib/jvm/java-11-openjdk-amd64
+  aarch64: /usr/lib/jvm/java-11-openjdk-arm64
 bazel_jobs: 40  # Default value between 1-40
 nginx_domain: localhost

--- a/roles/resilientdb/tasks/dependencies.yml
+++ b/roles/resilientdb/tasks/dependencies.yml
@@ -19,14 +19,30 @@
   apt_repository:
     repo: "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8"
     state: present
+  when: ansible_architecture == "x86_64"
 
 - name: Update apt cache
   apt:
     update_cache: yes
     cache_valid_time: 3600
+  when: ansible_architecture == "x86_64"
 
 - name: Install Bazel
   apt:
     name: "bazel={{ bazel_version }}"
     state: present
     force: yes
+  when: ansible_architecture == "x86_64"
+
+
+- name: Install Bazel manually in one stage
+  become: yes
+  block:
+    - name: Download and install Bazel 6.0.0
+      shell: |
+        curl -Lo /usr/local/bin/bazel https://releases.bazel.build/6.0.0/release/bazel-6.0.0-linux-arm64
+        chmod +x /usr/local/bin/bazel
+        bazel version
+      args:
+        executable: /bin/bash
+  when: ansible_architecture == "aarch64"

--- a/roles/resilientdb/tasks/service.yml
+++ b/roles/resilientdb/tasks/service.yml
@@ -50,7 +50,7 @@
   args:
     chdir: "{{ resilientdb_dir }}"
   environment:
-    JAVA_HOME: "{{ java_home }}"
+    JAVA_HOME: "{{ java_home_map[ansible_architecture] }}"
 
 - name: Ensure certificates directory exists
   file:


### PR DESCRIPTION
Detect the platform in the playbook using ansible_architecture ["x86_64" for amd64; "aarch64" for arm64]
Install Bazel using the respective methods, as Bazel does not support installing through the apt repository for arm64.
Configure JAVA_HOME with the correct JDK based on the architecture.